### PR TITLE
Switched to new ref linking needed for successful use with React v16

### DIFF
--- a/assets/js/src/components/ResponsiveImage.jsx
+++ b/assets/js/src/components/ResponsiveImage.jsx
@@ -74,9 +74,11 @@ class ResponsiveImage extends React.Component {
       ` ${className}` : '';
     const newClassName = `component-responsive-image${additionalClass}`;
 
-    return (<div className={newClassName}>
-      {currentSizeClone}
-    </div>);
+    return (
+      <div className={newClassName}>
+        {currentSizeClone}
+      </div>
+    );
   }
 
 
@@ -132,7 +134,7 @@ class ResponsiveImage extends React.Component {
       loadImage,
       onLoad,
       preloadBackground,
-      ref: 'currentImageSize',
+      ref: cis => (this._currentImageSize = cis),
       imageStyle,
       windowSize,
     });
@@ -171,7 +173,7 @@ class ResponsiveImage extends React.Component {
    */
   loadImage() {
     this.setState({ loadInitiated: true });
-    this.refs.currentImageSize.preloadImage();
+    this._currentImageSize.preloadImage();
   }
 }
 

--- a/assets/js/src/components/ResponsiveImageSize.jsx
+++ b/assets/js/src/components/ResponsiveImageSize.jsx
@@ -58,9 +58,11 @@ class ResponsiveImageSize extends React.Component {
       backgroundClass +
       loadedClass;
 
-    return (<div className={className}>
-      {imageElement}
-    </div>);
+    return (
+      <div className={className}>
+        {imageElement}
+      </div>
+    );
   }
 
 
@@ -79,7 +81,7 @@ class ResponsiveImageSize extends React.Component {
           alt={alt}
           onLoad={this.onLoad}
           onError={this.onError}
-          ref='image'
+          ref={image => this._image = image}
           src={imagePath}
           style={imageStyle}
         />
@@ -89,10 +91,10 @@ class ResponsiveImageSize extends React.Component {
         backgroundImage: 'url(' + imagePath + ')',
       };
       const propStyle = imageStyle || {};
-      const style = Object.assign(propStyle, backgroundStyle);
+      const style = Object.assign({}, propStyle, backgroundStyle);
 
       element = (
-        <div style={style} >
+        <div style={style}>
           {children}
         </div>
       );


### PR DESCRIPTION
Using existing ResponsiveImage with React v16 results in runtime render errors due to the use of ref elements that are strings. This PR fixes that by switching to the callback mechanism.